### PR TITLE
Code-input can be registered post-creation - #6

### DIFF
--- a/code-input.css
+++ b/code-input.css
@@ -90,3 +90,10 @@ code-input textarea {
   resize: none;
   outline: none!important;
 }
+
+code-input:not(.code-input_registered)::before {
+  /* Display message to register */
+  content: "Use codeInput.registerTemplate to set up.";
+  display: block;
+  color: grey;
+}


### PR DESCRIPTION
You can now register a code-input template after it has been used on the page.
A warning message is shown if a template is not registered, and automatically is replaced by the the template once it is registered.