### PR TITLE
expose children elements

### DIFF
--- a/code-input.js
+++ b/code-input.js
@@ -322,10 +322,11 @@ var codeInput = {
         }
 
         /**
-        * expose textarea and pre elements
+        * expose children elements
         */
-        textarea = null;
-        pre = null;
+        TEXTAREA = null;
+        PRE = null;
+        CODE = null;
 
         /**
          * When events are transferred to the textarea element, callbacks
@@ -374,10 +375,10 @@ var codeInput = {
             this.ignoreValueUpdate = true;
             this.value = value;
             this.ignoreValueUpdate = false;
-            if (this.querySelector("textarea").value != value) this.querySelector("textarea").value = value;
+            if (this.TEXTAREA.value != value) this.TEXTAREA.value = value;
 
 
-            let resultElement = this.querySelector("pre code");
+            let resultElement = this.CODE;
 
             // Handle final newlines
             if (value[value.length - 1] == "\n") {
@@ -399,8 +400,8 @@ var codeInput = {
          * Synchronise the scrolling of the textarea to the result element.
          */
         syncScroll() {
-            let inputElement = this.querySelector("textarea");
-            let resultElement = this.template.preElementStyled ? this.querySelector("pre") : this.querySelector("pre code");
+            let inputElement = this.TEXTAREA;
+            let resultElement = this.template.preElementStyled ? this.PRE : this.CODE;
 
             resultElement.scrollTop = inputElement.scrollTop;
             resultElement.scrollLeft = inputElement.scrollLeft;
@@ -481,8 +482,9 @@ var codeInput = {
             pre.append(code);
             this.append(pre);
 
-            this.textarea = textarea;
-            this.pre = pre;
+            this.TEXTAREA = textarea;
+            this.PRE = pre;
+            this.CODE = code;
 
             if (this.template.isCode) {
                 if (lang != undefined && lang != "") {
@@ -556,7 +558,7 @@ var codeInput = {
                         this.update(newValue);
                         break;
                     case "placeholder":
-                        this.querySelector("textarea").placeholder = newValue;
+                        this.TEXTAREA.placeholder = newValue;
                         break;
                     case "template":
                         this.template = codeInput.usedTemplates[newValue || codeInput.defaultTemplate];
@@ -569,8 +571,8 @@ var codeInput = {
 
                     case "lang":
 
-                        let code = this.querySelector("pre code");
-                        let mainTextarea = this.querySelector("textarea");
+                        let code = this.CODE;
+                        let mainTextarea = this.TEXTAREA;
 
                         // Check not already updated
                         if (newValue != null) {
@@ -602,7 +604,7 @@ var codeInput = {
                         break;
                     default:
                         if (codeInput.textareaSyncAttributes.includes(name)) {
-                            this.querySelector("textarea").setAttribute(name, newValue);
+                            this.TEXTAREA.setAttribute(name, newValue);
                         }
                         break;
                 }
@@ -625,9 +627,9 @@ var codeInput = {
 
             if (codeInput.textareaSyncEvents.includes(type)) {
                 if (options === undefined) {
-                    this.querySelector("textarea").addEventListener(type, boundCallback);
+                    this.TEXTAREA.addEventListener(type, boundCallback);
                 } else {
-                    this.querySelector("textarea").addEventListener(type, boundCallback, options);
+                    this.TEXTAREA.addEventListener(type, boundCallback, options);
                 }
             } else {
                 if (options === undefined) {
@@ -645,15 +647,15 @@ var codeInput = {
             let boundCallback = this.boundEventCallbacks[listener];
             if (type == "change") {
                 if (options === null) {
-                    this.querySelector("textarea").removeEventListener("change", boundCallback);
+                    this.TEXTAREA.removeEventListener("change", boundCallback);
                 } else {
-                    this.querySelector("textarea").removeEventListener("change", boundCallback, options);
+                    this.TEXTAREA.removeEventListener("change", boundCallback, options);
                 }
             } else if (type == "selectionchange") {
                 if (options === null) {
-                    this.querySelector("textarea").removeEventListener("selectionchange", boundCallback);
+                    this.TEXTAREA.removeEventListener("selectionchange", boundCallback);
                 } else {
-                    this.querySelector("textarea").removeEventListener("selectionchange", boundCallback, options);
+                    this.TEXTAREA.removeEventListener("selectionchange", boundCallback, options);
                 }
             } else {
                 super.removeEventListener(type, listener, options);
@@ -696,7 +698,7 @@ var codeInput = {
          * See `HTMLTextAreaElement.validity`
          */
         get validity() {
-            return this.querySelector("textarea").validity;
+            return this.TEXTAREA.validity;
         }
 
         /**
@@ -707,7 +709,7 @@ var codeInput = {
          * See `HTMLTextAreaElement.validationMessage`
          */
         get validationMessage() {
-            return this.querySelector("textarea").validationMessage;
+            return this.TEXTAREA.validationMessage;
         }
 
         /**
@@ -717,7 +719,7 @@ var codeInput = {
          * @param error Sets a custom error message that is displayed when a form is submitted.
          */
         setCustomValidity(error) {
-            return this.querySelector("textarea").setCustomValidity(error);
+            return this.TEXTAREA.setCustomValidity(error);
         }
 
         /**
@@ -727,14 +729,14 @@ var codeInput = {
          * See `HTMLTextAreaElement.checkValidity`
          */
         checkValidity() {
-            return this.querySelector("textarea").checkValidity();
+            return this.TEXTAREA.checkValidity();
         }
 
         /**
          * See `HTMLTextAreaElement.reportValidity`
          */
         reportValidity() {
-            return this.querySelector("textarea").reportValidity();
+            return this.TEXTAREA.reportValidity();
         }
 
 
@@ -743,17 +745,17 @@ var codeInput = {
          */
         setAttribute(qualifiedName, value) {
             super.setAttribute(qualifiedName, value); // code-input
-            this.querySelector("textarea").setAttribute(qualifiedName, value); // textarea
+            this.TEXTAREA.setAttribute(qualifiedName, value); // textarea
         }
 
         /**
          * @override
          */
         getAttribute(qualifiedName) {
-            if (this.querySelector("textarea") == null) {
+            if (this.TEXTAREA == null) {
                 return super.getAttribute(qualifiedName);
             }
-            return this.querySelector("textarea").getAttribute(qualifiedName); // textarea
+            return this.TEXTAREA.getAttribute(qualifiedName); // textarea
         }
 
         /**

--- a/code-input.js
+++ b/code-input.js
@@ -322,6 +322,12 @@ var codeInput = {
         }
 
         /**
+        * expose textarea and pre elements
+        */
+        textarea = null;
+        pre = null;
+
+        /**
          * When events are transferred to the textarea element, callbacks
          * are bound to set the this variable to the code-inpute element
          * rather than the textarea. This allows the callback to be converted
@@ -474,6 +480,9 @@ var codeInput = {
             pre.setAttribute("aria-hidden", "true"); // Hide for screen readers
             pre.append(code);
             this.append(pre);
+
+            this.textarea = textarea;
+            this.pre = pre;
 
             if (this.template.isCode) {
                 if (lang != undefined && lang != "") {


### PR DESCRIPTION
In some cases access to `textarea` and `pre`/`code` elements are needed. (selecting/marking text).
In addition, this allows remove unnecessary internal `querySelector` calls.