### PR TITLE
don't store value in attribute

### DIFF
--- a/code-input.js
+++ b/code-input.js
@@ -320,10 +320,14 @@ var codeInput = {
         constructor() {
             super(); // Element
         }
+        /**
+        * Store value internally
+        */
+        _value = '';
 
         /**
          * When events are transferred to the textarea element, callbacks
-         * are bound to set the this variable to the code-inpute element
+         * are bound to set the this variable to the code-input element
          * rather than the textarea. This allows the callback to be converted
          * to a bound one:
          * Key - Callback not bound
@@ -544,7 +548,7 @@ var codeInput = {
                 switch (name) {
 
                     case "value":
-                        this.update(newValue);
+                        this.value = newValue;
                         break;
                     case "placeholder":
                         this.querySelector("textarea").placeholder = newValue;
@@ -655,14 +659,18 @@ var codeInput = {
          * Get the text contents of the code-input element.
          */
         get value() {
-            return this.getAttribute("value");
+            return this._value;
         }
         /**
          * Set the text contents of the code-input element.
          * @param {string} val - New text contents
          */
         set value(val) {
-            return this.setAttribute("value", val);
+            if (val === null || val === undefined) {
+                val = "";
+            }
+            this.update(val);
+            return val;
         }
 
         /**


### PR DESCRIPTION
This also fixes an error when `value` attribute removed from the element.