### PR TITLE
Form reset uses innerHTML., not value attr.

### DIFF
--- a/code-input.js
+++ b/code-input.js
@@ -801,10 +801,10 @@ var codeInput = {
         pluginData = {};
 
         /**
-        * Update value on form reset from value attribute
+        * Update value on form reset
         */
         formResetCallback() {
-            this.update(this.querySelector("textarea").getAttribute("value"));
+            this.update(this.textareaElement.innerHTML);
         }
     }
 }


### PR DESCRIPTION
textarea does not have value attribute. So, on form reset it uses innerHTML as initial value.