### PR TITLE
Cursor below view

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 ---
 # Ways you could contribute:
 ## 1. I've found a bug but don't know how / don't have time to fix it.
-If you think you've found a bug, please [submit an issue](https://github.com/WebCoder49/code-input/issues) with screenshots, how you found the bug, and copies of the console's logs if an error is in them. Please also mention the template and plugins you used (your `codeInput.registerTemplate(...)` snippet). We'd be more than happy to help you fix it.
+If you think you've found a bug, please [submit an issue](https://github.com/WebCoder49/code-input/issues) with screenshots, how you found the bug, and copies of the console's logs if an error is in them. Please also mention the template and plugins you used (your `codeInput.registerTemplate(...)` snippet). We'd be more than happy to help you fix it. A demo using [CodePen](https://codepen.io/) would be incredibly useful.
 
 ## 2. I have implemented a feature / have thought of a potential feature for the library and think it could be useful for others.
 The best way to implement a feature is as a plugin like those in the `plugins` folder of `code-input`. If you do this, you could contribute it as in point 3 below.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The next step is to set up a `template` to link `code-input` to your syntax-high
       hljs, 
       [
         new codeInput.plugins.Autodetect(), 
-        new codeInput.plugins.Indent()
+        new codeInput.plugins.Indent(true, 2) // 2 spaces indentation
       ]
     )
   );
@@ -119,7 +119,7 @@ Now that you have registered a template, you can use the custom `<code-input>` e
   ```
 
 ## Contributing
-If you have any features you would like to add to `code-input`, or have found any bugs, please [open an issue](https://github.com/WebCoder49/code-input/issues) or [fork and submit a pull request](https://github.com/WebCoder49/code-input/fork)! All contributions to this open-source project would be greatly appreciated.
+If you have any features you would like to add to `code-input` as plugins or core functionality, or have found any bugs, please [open an issue](https://github.com/WebCoder49/code-input/issues) or [fork and submit a pull request](https://github.com/WebCoder49/code-input/fork)! All contributions to this open-source project will be greatly appreciated. You can see [more info in our `CONTRIBUTING.md` file](CONTRIBUTING.md).
 
 
 |[![Contributors](https://contrib.rocks/image?repo=WebCoder49%2Fcode-input)](https://github.com/WebCoder49/code-input/graphs/contributors)|

--- a/code-input.css
+++ b/code-input.css
@@ -83,12 +83,15 @@ code-input:not(.code-input_loaded)::after {
   color: #ccc;
 }
 
-/* Make textarea almost completely transparent */
+/* Make textarea almost completely transparent, except for caret and placeholder */
 
 code-input textarea {
   color: transparent;
   background: transparent;
   caret-color: inherit!important; /* Or choose your favourite color */
+}
+code-input textarea::placeholder {
+  color: lightgrey;
 }
 
 /* Can be scrolled */

--- a/code-input.d.ts
+++ b/code-input.d.ts
@@ -116,7 +116,12 @@ export namespace plugins {
    * Files: indent.js
    */
   class Indent extends Plugin {
-    constructor();
+    /**
+     * Create an indentation plugin to pass into a template
+     * @param {Boolean} defaultSpaces Should the Tab key enter spaces rather than tabs? Defaults to false.
+     * @param {Number} numSpaces How many spaces is each tab character worth? Defaults to 4.
+     */
+    constructor(defaultSpaces?: boolean, numSpaces?: Number);
   }
 
   /**

--- a/code-input.js
+++ b/code-input.js
@@ -774,7 +774,6 @@ var codeInput = {
                         oldValue = oldValue.toLowerCase();
 
                         // Remove old language class and add new
-                        console.log("code-input: Language: REMOVE", "language-" + oldValue);
                         code.classList.remove("language-" + oldValue); // From codeElement
                         code.parentElement.classList.remove("language-" + oldValue); // From preElement
                         code.classList.remove("language-none"); // Prism
@@ -782,7 +781,6 @@ var codeInput = {
 
                         if (newValue != undefined && newValue != "") {
                             code.classList.add("language-" + newValue);
-                            console.log("code-input: Language: ADD", "language-" + newValue);
                         }
 
                         if (mainTextarea.placeholder == oldValue) mainTextarea.placeholder = newValue;
@@ -792,8 +790,7 @@ var codeInput = {
                         break;
                     default:
                         if (codeInput.textareaSyncAttributes.includes(name)) {
-                            console.log("sync", name, oldValue, newValue);
-                            if(newValue == null || newValue == undefined) { // TODO: Console.Log to check reaches here with disabled attribute; Fix for disabled attr removal
+                            if(newValue == null || newValue == undefined) {
                                 this.textareaElement.removeAttribute(name);
                             } else {
                                 this.textareaElement.setAttribute(name, newValue);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webcoder49/code-input",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Fully customisable, editable syntax-highlighted textareas.",
   "browser": "code-input.js",
   "scripts": {

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,6 +1,12 @@
 # Code-input: Plugins
 ## List Of Plugins
 
+💡 Do you just want to get a quick editor working? We suggest the [Indent](#indent) and [Prism Line Numbers](#prism-line-numbers) plugins.
+
+**Lots of plugins are very customisable - please see the JavaScript files for parameters and if you want more features let us know via GitHub Issues.**
+
+---
+
 ### Autocomplete
 Display a popup under the caret using the text in the code-input element. This works well with autocomplete suggestions.
 
@@ -23,7 +29,7 @@ Files: [debounce-update.js](./debounce-update.js)
 [🚀 *CodePen Demo*](https://codepen.io/WebCoder49/pen/GRXyxzV)
 
 ### Indent
-Adds indentation using the `Tab` key, and auto-indents after a newline, as well as making it possible to indent/unindent multiple lines using Tab/Shift+Tab
+Adds indentation using the `Tab` key, and auto-indents after a newline, as well as making it possible to indent/unindent multiple lines using Tab/Shift+Tab. **Supports tab characters and custom numbers of spaces as indentation.**
 
 Files: [indent.js](./indent.js)
 
@@ -60,7 +66,7 @@ Plugins allow you to add extra features to a template, like [automatic indentati
       hljs, 
       [
         new codeInput.plugins.Autodetect(), 
-        new codeInput.plugins.Indent()
+        new codeInput.plugins.Indent(true, 2) // 2 spaces indentation
       ]
     )
   );

--- a/plugins/autocomplete.js
+++ b/plugins/autocomplete.js
@@ -13,7 +13,7 @@ codeInput.plugins.Autocomplete = class extends codeInput.Plugin {
     }
     /* When a key is pressed, or scrolling occurs, update the autocomplete */
     updatePopup(codeInput, onlyScrolled) {
-        let textarea = codeInput.querySelector("textarea");
+        let textarea = codeInput.textareaElement;
         let caretCoords = this.getCaretCoordinates(codeInput, textarea, textarea.selectionEnd, onlyScrolled);
         let popupElem = codeInput.querySelector(".code-input_autocomplete_popup");
         popupElem.style.top = caretCoords.top + "px";
@@ -33,7 +33,7 @@ codeInput.plugins.Autocomplete = class extends codeInput.Plugin {
         testPosElem.classList.add("code-input_autocomplete_testpos");
         codeInput.appendChild(testPosElem); // Styled like first pre, but first pre found to update
 
-        let textarea = codeInput.querySelector("textarea");
+        let textarea = codeInput.textareaElement;
         textarea.addEventListener("keyup", this.updatePopup.bind(this, codeInput, false)); // Override this+args in bind - not just scrolling
         textarea.addEventListener("click", this.updatePopup.bind(this, codeInput, false)); // Override this+args in bind - not just scrolling
         textarea.addEventListener("scroll", this.updatePopup.bind(this, codeInput, true)); // Override this+args in bind - just scrolling

--- a/plugins/autodetect.js
+++ b/plugins/autodetect.js
@@ -9,15 +9,15 @@ codeInput.plugins.Autodetect = class extends codeInput.Plugin {
     }
     /* Remove previous language class */
     beforeHighlight(codeInput) {
-        let result_element = codeInput.querySelector("pre code");
-        result_element.className = ""; // CODE
-        result_element.parentElement.className = ""; // PRE
+        let resultElement = codeInput.codeElement;
+        resultElement.className = ""; // CODE
+        resultElement.parentElement.className = ""; // PRE
     }
     /* Get new language class and set `lang` attribute */
     afterHighlight(codeInput) {
-        let result_element = codeInput.querySelector("pre code");
-        let lang_class = result_element.className || result_element.parentElement.className;
-        let lang = lang_class.match(/lang(\w|-)*/i)[0]; // Get word starting with lang...; Get outer bracket
+        let resultElement = codeInput.codeElement;
+        let langClass = resultElement.className || resultElement.parentElement.className;
+        let lang = langClass.match(/lang(\w|-)*/i)[0]; // Get word starting with lang...; Get outer bracket
         lang = lang.split("-")[1];
         if(lang == "undefined") {
             codeInput.removeAttribute("lang");

--- a/plugins/debounce-update.js
+++ b/plugins/debounce-update.js
@@ -14,7 +14,6 @@ codeInput.plugins.DebounceUpdate = class extends codeInput.Plugin {
     }
     /* Runs before elements are added into a `code-input`; Params: codeInput element) */
     beforeElementsAdded(codeInput) {
-        console.log(codeInput, "before elements added");
         this.update = codeInput.update.bind(codeInput); // Save previous update func
         codeInput.update = this.updateDebounced.bind(this, codeInput);
     }

--- a/plugins/indent.js
+++ b/plugins/indent.js
@@ -10,145 +10,135 @@ codeInput.plugins.Indent = class extends codeInput.Plugin {
 
     /* Add keystroke events */
     afterElementsAdded(codeInput) {
-        let textarea = codeInput.querySelector("textarea");
-        textarea.addEventListener('keydown', (event) => { this.check_tab(codeInput, event); this.check_enter(codeInput, event); });
+        let textarea = codeInput.textareaElement;
+        textarea.addEventListener('keydown', (event) => { this.checkTab(codeInput, event); this.checkEnter(codeInput, event); });
     }
 
     /* Event handlers */
-    check_tab(codeInput, event) {
+    checkTab(codeInput, event) {
         if(event.key != "Tab") {
             return;
         }
-        let input_element = codeInput.querySelector("textarea");
-        let code = input_element.value;
+        let inputElement = codeInput.textareaElement;
         event.preventDefault(); // stop normal
         
-        if(!event.shiftKey && input_element.selectionStart == input_element.selectionEnd) {
+        if(!event.shiftKey && inputElement.selectionStart == inputElement.selectionEnd) {
             // Just place a tab here.
             document.execCommand("insertText", false, "\t");
 
         } else {
-            let lines = input_element.value.split("\n");
-            let letter_i = 0;
+            let lines = inputElement.value.split("\n");
+            let letterI = 0;
 
-            let selection_start = input_element.selectionStart; // where cursor moves after tab - moving forward by 1 indent
-            let selection_end = input_element.selectionEnd; // where cursor moves after tab - moving forward by 1 indent
+            let selectionStartI = inputElement.selectionStart; // where cursor moves after tab - moving forward by 1 indent
+            let selectionEndI = inputElement.selectionEnd; // where cursor moves after tab - moving forward by 1 indent
 
-            let number_indents = 0;
-            let first_line_indents = 0;
-
-            for (let i = 0; i < lines.length; i++) {                
-                // console.log(lines[i], ": start", selection_start, letter_i + lines[i].length + 1, "&& end", selection_end , letter_i + 1)
-                if((selection_start <= letter_i+lines[i].length && selection_end >= letter_i + 1)
-                || (selection_start == selection_end && selection_start <= letter_i+lines[i].length+1 && selection_end >= letter_i)) { // + 1 so newlines counted
+            for (let i = 0; i < lines.length; i++) {
+                if((selectionStartI <= letterI+lines[i].length && selectionEndI >= letterI + 1)
+                || (selectionStartI == selectionEndI && selectionStartI <= letterI+lines[i].length+1 && selectionEndI >= letterI)) { // + 1 so newlines counted
                     // Starts before or at last char and ends after or at first char
                     if(event.shiftKey) {
                         if(lines[i][0] == "\t") {
                             // Remove first tab
-                            input_element.selectionStart = letter_i;
-                            input_element.selectionEnd = letter_i+1;
+                            inputElement.selectionStart = letterI;
+                            inputElement.selectionEnd = letterI+1;
                             document.execCommand("delete", false, "");
 
                             // Change selection
-                            if(selection_start > letter_i) { // Indented outside selection
-                                selection_start--;
+                            if(selectionStartI > letterI) { // Indented outside selection
+                                selectionStartI--;
                             }
-                            selection_end--;
-                            letter_i--;
+                            selectionEndI--;
+                            letterI--;
                         }
                     } else {
                         // Add tab at start
-                        input_element.selectionStart = letter_i;
-                        input_element.selectionEnd = letter_i;
+                        inputElement.selectionStart = letterI;
+                        inputElement.selectionEnd = letterI;
                         document.execCommand("insertText", false, "\t");
 
                         // Change selection
-                        if(selection_start > letter_i) { // Indented outside selection
-                            selection_start++;
+                        if(selectionStartI > letterI) { // Indented outside selection
+                            selectionStartI++;
                         }
-                        selection_end++;
-                        letter_i++;
+                        selectionEndI++;
+                        letterI++;
                     }                    
                 }
                 
-                letter_i += lines[i].length+1; // newline counted
+                letterI += lines[i].length+1; // newline counted
             }
-            // input_element.value = lines.join("\n");
 
             // move cursor
-            input_element.selectionStart = selection_start;
-            input_element.selectionEnd = selection_end;
+            inputElement.selectionStart = selectionStartI;
+            inputElement.selectionEnd = selectionEndI;
         }
 
-        codeInput.update(input_element.value);
+        codeInput.update(inputElement.value);
     }
 
-    check_enter(codeInput, event) {
+    checkEnter(codeInput, event) {
         if(event.key != "Enter") {
             return;
         }
-        event.preventDefault(); // stop normal
+        event.preventDefault(); // Stop normal \n only
 
-        let input_element = codeInput.querySelector("textarea");
-        let lines = input_element.value.split("\n");
-        let letter_i = 0;
-        let current_line = lines.length - 1;
-        let new_line = "";
-        let number_indents = 0;
+        let inputElement = codeInput.querySelector("textarea");
+        let lines = inputElement.value.split("\n");
+        let letterI = 0;
+        let currentLineI = lines.length - 1;
+        let newLine = "";
+        let numberIndents = 0;
 
         // find the index of the line our cursor is currently on
         for (let i = 0; i < lines.length; i++) {
-            letter_i += lines[i].length + 1;
-            if(input_element.selectionEnd <= letter_i) {
-                current_line = i;
+            letterI += lines[i].length + 1;
+            if(inputElement.selectionEnd <= letterI) {
+                currentLineI = i;
                 break;
             }
         }
 
         // count the number of indents the current line starts with (up to our cursor position in the line)
-        let cursor_pos_in_line = lines[current_line].length - (letter_i - input_element.selectionEnd) + 1;
-        for (let i = 0; i < cursor_pos_in_line; i++) {
-            if (lines[current_line][i] == "\t") {
-                number_indents++;
+        let cursorPosInLine = lines[currentLineI].length - (letterI - inputElement.selectionEnd) + 1;
+        for (let i = 0; i < cursorPosInLine; i++) {
+            if (lines[currentLineI][i] == "\t") {
+                numberIndents++;
             } else {
                 break;
             }
         }
 
         // determine the text before and after the cursor and chop the current line at the new line break
-        let text_after_cursor = "";
-        if (cursor_pos_in_line != lines[current_line].length) {
-            text_after_cursor = lines[current_line].substring(cursor_pos_in_line);
-            lines[current_line] = lines[current_line].substring(0, cursor_pos_in_line);
+        let textAfterCursor = "";
+        if (cursorPosInLine != lines[currentLineI].length) {
+            textAfterCursor = lines[currentLineI].substring(cursorPosInLine);
+            lines[currentLineI] = lines[currentLineI].substring(0, cursorPosInLine);
         }
 
         // insert our indents and any text from the previous line that might have been after the line break
-        for (let i = 0; i < number_indents; i++) {
-            new_line += "\t";
+        for (let i = 0; i < numberIndents; i++) {
+            newLine += "\t";
         }
 
         // save the current cursor position
-        let selection_start = input_element.selectionStart;
-        let selection_end = input_element.selectionEnd;
+        let selectionStartI = inputElement.selectionStart;
 
-        document.execCommand("insertText", false, "\n" + new_line); // Write new line, including auto-indentation
+        document.execCommand("insertText", false, "\n" + newLine); // Write new line, including auto-indentation
 
         // move cursor to new position
-        input_element.selectionStart = selection_start + number_indents + 1;  // count the indent level and the newline character
-        input_element.selectionEnd = selection_start + number_indents + 1;
+        inputElement.selectionStart = selectionStartI + numberIndents + 1;  // count the indent level and the newline character
+        inputElement.selectionEnd = inputElement.selectionStart;
 
-        codeInput.update(input_element.value);
-
-
-        // Update scrolls
-        input_element.scrollLeft = 0;
-        // Move down 1 line
-        let lineHeight = Number(getComputedStyle(input_element).lineHeight.split(0, -2));
-        // console.log(getComputedStyle(input_element).lineHeight);
-        if(lineHeight == NaN && getComputedStyle(input_element).lineHeight.split(-2) == "px") {
-            input_element.scrollTop += lineHeight;
-        } else {
-            input_element.scrollTop += 20; // px
+        
+        // Scroll down to cursor if necessary
+        let paddingTop = Number(getComputedStyle(inputElement).paddingTop.replace("px", "")); 
+        let lineHeight = Number(getComputedStyle(inputElement).lineHeight.replace("px", "")); 
+        let inputHeight = Number(getComputedStyle(inputElement).height.replace("px", ""));
+        if(currentLineI*lineHeight + lineHeight*2 + paddingTop >= inputElement.scrollTop + inputHeight) { // Cursor too far down
+            inputElement.scrollBy(0, Number(getComputedStyle(inputElement).lineHeight.replace("px", "")))
         }
+
+        codeInput.update(inputElement.value);
     }
 }

--- a/plugins/special-chars.js
+++ b/plugins/special-chars.js
@@ -143,8 +143,6 @@ codeInput.plugins.SpecialChars = class extends codeInput.Plugin {
             // Calculate darkness
             text_color = color_brightness < 128 ? "white" : "black";
 
-            // console.log(background_color, color_brightness, text_color);
-
             this.cachedColors[ascii_code] = [background_color, text_color];
             return [background_color, text_color];
         } else {
@@ -172,7 +170,6 @@ codeInput.plugins.SpecialChars = class extends codeInput.Plugin {
         }
 
         // Ensure font the same
-        // console.log(font);
         this.canvasContext.font = font;
 
         // Try to get width from canvas
@@ -186,33 +183,6 @@ codeInput.plugins.SpecialChars = class extends codeInput.Plugin {
 
         this.cachedWidths[font][char] = width;
 
-        // console.log(this.cachedWidths);
         return width;
     }
-
-    // getCharacterWidth(char) { // Doesn't work for now - from StackOverflow suggestion https://stackoverflow.com/a/76146120/21785620
-    //     let textarea = codeInput.pluginData.specialChars.textarea;
-
-    //     // Create a temporary element to measure the width of the character
-    //     const span = document.createElement('span');
-    //     span.textContent = char;
-        
-    //     // Copy the textarea's font to the temporary element
-    //     span.style.fontSize = window.getComputedStyle(textarea).fontSize;
-    //     span.style.fontFamily = window.getComputedStyle(textarea).fontFamily;
-    //     span.style.fontWeight = window.getComputedStyle(textarea).fontWeight;
-    //     span.style.visibility = 'hidden';
-    //     span.style.position = 'absolute';
-        
-    //     // Add the temporary element to the document so we can measure its width
-    //     document.body.appendChild(span);
-        
-    //     // Get the width of the character in pixels
-    //     const width = span.offsetWidth;
-        
-    //     // Remove the temporary element from the document
-    //     document.body.removeChild(span);
-        
-    //     return width;
-    // }
 }


### PR DESCRIPTION
* Make `code-input` scroll so cursor always visible (closes #61)
* Allow indentation with spaces as well as tabs (closes #62)
* Clean up `indent` plugin