### PR TITLE
Fix adding element after DOM is already loaded

### DIFF
--- a/code-input.js
+++ b/code-input.js
@@ -831,8 +831,12 @@ var codeInput = {
             if (this.templateObject != undefined) {
                 // Template registered before loading
                 this.classList.add("code-input_registered");
-                // Children not yet present - wait until they are
-                window.addEventListener("DOMContentLoaded", this.setup.bind(this))
+                if (document.readyState === 'loading') {
+                    // Children not yet present - wait until they are
+                    window.addEventListener("DOMContentLoaded", this.setup.bind(this))
+                } else {
+                    this.setup();
+                }
             } 
         }
 

--- a/code-input.js
+++ b/code-input.js
@@ -863,7 +863,9 @@ var codeInput = {
         }
 
         disconnectedCallback() {
-            this.mutationObserver.disconnect();
+            if (this.mutationObserver) {
+                this.mutationObserver.disconnect();
+            }
         }
 
         /**

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -217,6 +217,14 @@ console.log("I've got another line!", 2 < 3, "should be true.");`);
 console.log("I've got another line!", 2 &lt; 3, "should be true.");
 `); // Extra newline so line numbers visible if enabled
 
+    const programmaticCodeInput = document.createElement("code-input");
+    document.body.append(programmaticCodeInput);
+    programmaticCodeInput.focus();
+    document.execCommand("insertText", false, "Hello, World!");
+    assertEqual("Core", "Programmatically-created element JS-accessible value", programmaticCodeInput.value, "Hello, World!");
+    await waitAsync(50);
+    assertEqual("Core", "Programmatically-created element rendered value", programmaticCodeInput.preElement.textContent, "Hello, World!\n");
+
     // Event Listener Tests
     // Function type listeners
     let numTimesInputCalled = 0;


### PR DESCRIPTION
When you add a `<code-input>` element to the DOM *after* the webpage is already loaded, the element isn't set up properly. This happens because we're always adding a `DOMContentLoaded` listener, even when that event has already been fired before.

Similarly, when you remove a `<code-input>` from the DOM before it has had the chance to set up, the `disconnectedCallback` would throw because `this.mutationObserver` wasn't set yet.