### PR TITLE
Fix FindAndReplace and GoToLine plugins' error styles

### DIFF
--- a/plugins/find-and-replace.css
+++ b/plugins/find-and-replace.css
@@ -60,7 +60,7 @@
 }
 
 .code-input_find-and-replace_dialog input.code-input_find-and-replace_error {
-  color: #ff0000aa;
+  color: #b60000;
 }
 
 .code-input_find-and-replace_dialog button, .code-input_find-and-replace_dialog input[type="checkbox"] {

--- a/plugins/find-and-replace.js
+++ b/plugins/find-and-replace.js
@@ -123,6 +123,9 @@ codeInput.plugins.FindAndReplace = class extends codeInput.Plugin {
                         // No matches - error
                         dialog.findInput.classList.add('code-input_find-and-replace_error');
                     }
+                } else {
+                    // Input box is empty - no error
+                    dialog.findInput.classList.remove('code-input_find-and-replace_error');
                 }
                 this.updateMatchDescription(dialog);
             }

--- a/plugins/go-to-line.css
+++ b/plugins/go-to-line.css
@@ -43,7 +43,7 @@
 }
 
 .code-input_go-to-line_dialog input.code-input_go-to-line_error {
-  color: #ff0000aa;
+  color: #b60000;
 }
 
 /* Cancel icon */

--- a/plugins/go-to-line.js
+++ b/plugins/go-to-line.js
@@ -81,8 +81,9 @@ codeInput.plugins.GoToLine = class extends codeInput.Plugin {
                 }
             }
         } else {
-            // No value
+            // No value, so no message or error
             dialog.guidance.textContent = "";
+            dialog.input.classList.remove('code-input_go-to-line_error');
         }
 
         if (event.key == 'Enter') {


### PR DESCRIPTION
* Make empty input never have error style: Fixes #220
* Improve error style contrast: Fixes #218