### PR TITLE
Make find-and-replace search from the caret's position when opened (Fixes #156)

### DIFF
--- a/plugins/find-and-replace.js
+++ b/plugins/find-and-replace.js
@@ -186,7 +186,9 @@ codeInput.plugins.FindAndReplace = class extends codeInput.Plugin {
     }
 
     /**
-     * Show a find-and-replace dialog.
+     * Show a find-and-replace dialog. The first match focused is the first one at or
+     * after the caret's position when this is called, wrapping back round to the start
+     * of the code if there is no such match.
      * @param {codeInput.CodeInput} codeInputElement the `<code-input>` element.
      * @param {boolean} replacePartExpanded whether the replace part of the find-and-replace dialog should be expanded
     */
@@ -411,6 +413,12 @@ codeInput.plugins.FindAndReplace = class extends codeInput.Plugin {
         // Save selection position
         dialog.selectionStart = codeInputElement.textareaElement.selectionStart;
         dialog.selectionEnd = codeInputElement.textareaElement.selectionEnd;
+
+        // Start searching from the caret's position at the moment the dialog was
+        // opened, like most IDEs do. The findMatchState is only constructed when the
+        // dialog is first created, so without this every reopening of the dialog would
+        // carry on from wherever the previous search left off instead.
+        dialog.findMatchState.focusedMatchStartIndex = dialog.selectionStart;
 
         if(dialog.selectionStart < dialog.selectionEnd) {
             // Copy selected text to Find input

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -761,6 +761,38 @@ console.log("I've got another line!", 2 &lt; 3, "should be true.");
     codeInputElement.querySelector(".code-input_find-and-replace_dialog").dispatchEvent(new KeyboardEvent("keydown", { "key": "Escape" }));
     codeInputElement.querySelector(".code-input_find-and-replace_dialog").dispatchEvent(new KeyboardEvent("keyup", { "key": "Escape" }));
 
+    // Opening the dialog searches from the caret's position at that moment, rather than
+    // carrying on from wherever the previous search left off. In the code above, "hi" is
+    // at indexes 3, 16 and 29.
+    // Open the dialog with the caret at the given index, then close it, which selects the
+    // focused match; returns the index that match starts at.
+    async function findFromCaret(caret) {
+        findInput.value = "hi";
+        textarea.focus();
+        textarea.selectionStart = textarea.selectionEnd = caret;
+        if(navigator.platform.startsWith("Mac") || navigator.platform === "iPhone") {
+            textarea.dispatchEvent(new KeyboardEvent("keydown", { "cancelable": true, "key": "f", "metaKey": true }));
+        } else {
+            textarea.dispatchEvent(new KeyboardEvent("keydown", { "cancelable": true, "key": "f", "ctrlKey": true }));
+        }
+        await waitAsync(250); // Wait for highlighting so matches update
+
+        const dialog = codeInputElement.querySelector(".code-input_find-and-replace_dialog");
+        dialog.dispatchEvent(new KeyboardEvent("keydown", { "key": "Escape" }));
+        dialog.dispatchEvent(new KeyboardEvent("keyup", { "key": "Escape" }));
+        await waitAsync(150); // Wait for the dialog to close and select the focused match
+
+        return textarea.selectionStart;
+    }
+
+    // These two are ordered so the match the previous one left focused differs from the
+    // correct answer, so they fail if the caret's position is ignored.
+    assertEqual("FindAndReplace", "Finds First Match After Caret when Reopened", await findFromCaret(17), 29);
+    assertEqual("FindAndReplace", "Finds Match Starting Exactly at Caret", await findFromCaret(16), 16);
+    // These two lock in the surrounding behaviour, and pass either way.
+    assertEqual("FindAndReplace", "Wraps to First Match when Caret is After Last Match", await findFromCaret(30), 3);
+    assertEqual("FindAndReplace", "Keeps Focused Match when Reopened without Moving Caret", await findFromCaret(3), 3);
+
     // GoToLine
     // Replace all code
     textarea.selectionStart = 0;


### PR DESCRIPTION
Fixes #156.

## The cause

`FindMatchState` stores `focusedMatchStartIndex`, the position `focusMatch()` searches forward from, and its constructor initialises it from the caret. But it is constructed in only one place — inside the branch of `showPrompt` that runs when the dialog does not yet exist:

https://github.com/WebCoder49/code-input/blob/v2.8.3/plugins/find-and-replace.js#L313

Every subsequent Ctrl+F reuses the cached dialog and its `findMatchState`, so `focusedMatchStartIndex` still holds the position of the match the *previous* search left focused. The first search after a page load starts from the caret correctly; every one after it carries on from where the last one stopped.

## The change

One line, next to where `showPrompt` already saves the selection for both the create and the reopen paths, so it applies either way and runs before the closing `updateFindMatches` recomputes the matches:

```js
dialog.findMatchState.focusedMatchStartIndex = dialog.selectionStart;
```

Existing behaviour this deliberately preserves:

- Closing the dialog selects the focused match (`cancelPrompt`), so reopening without moving the caret stays on that match rather than jumping forward — the same as VS Code.
- Opening with text selected still copies it into the find field, and since the caret is that selection's start, the selection itself is the first match.
- With no match at or after the caret, it still wraps round to the first match in the code.

## Behaviour change

Flagging this as the breaking change the issue was labelled: reopening the dialog now moves the focused match where previously it did not. Anything driving `showPrompt` programmatically and relying on the search resuming from the last match will see a different match focused.

## Tests

Four assertions added to the `FindAndReplace` group in `tests/tester.js`. They are automated `assertEqual`s — no `confirm()` judgement needed — and slot in after the existing find-and-replace block, leaving the sequential state the later GoToLine tests depend on untouched.

I checked they actually fail without the fix rather than assuming it, by reverting the one-line change and re-running:

| Test | Without the fix | With the fix |
| --- | --- | --- |
| Finds First Match After Caret when Reopened | fails (3, expected 29) | passes |
| Finds Match Starting Exactly at Caret | fails (3, expected 16) | passes |
| Wraps to First Match when Caret is After Last Match | passes | passes |
| Keeps Focused Match when Reopened without Moving Caret | passes | passes |

The first two are ordered so the match the previous one leaves focused differs from the correct answer, which is what makes them fail when the caret is ignored. The last two cannot discriminate in a chained sequence — once the first case fails, the stale position *is* the first match — so they are commented as locking in the surrounding behaviour rather than guarding this fix.

That table comes from a standalone page in Chromium using a minimal custom template, driving the real `Ctrl`/`Cmd`+`F` key events rather than calling `showPrompt` directly. The change is in `showPrompt`, above any highlighting, so it is not template-specific — but I have not yet run the full `tests/prism.html` / `tests/hljs.html` pages end to end, since they need a person to answer the `confirm()` prompts. Happy to do that and report back if you'd like it before merging.

## Not included

- `*.min.js` — left to the Auto-minify workflow.
- `esm/` — generated at `prepack`; no marker comments affected.
- `code-input.d.ts` — no public interface change (`showPrompt`'s docstring is updated in the plugin itself).
